### PR TITLE
Unstake retired

### DIFF
--- a/contracts/l1/Depository.sol
+++ b/contracts/l1/Depository.sol
@@ -106,6 +106,8 @@ contract Depository is Implementation {
     bytes32 public constant STAKE = 0x1bcc0f4c3fad314e585165815f94ecca9b96690a26d6417d7876448a9a867a69;
     // Unstake operation
     bytes32 public constant UNSTAKE = 0x8ca9a95e41b5eece253c93f5b31eed1253aed6b145d8a6e14d913fdf8e732293;
+    // Unstake-retired operation
+    bytes32 public constant UNSTAKE_RETIRED = 0x9065ad15d9673159e4597c86084aff8052550cec93c5a6e44b3f1dba4c8731b3;
 
     // OLAS contract address
     address public immutable olas;
@@ -135,6 +137,37 @@ contract Depository is Implementation {
     constructor(address _olas, address _st) {
         olas = _olas;
         st = _st;
+    }
+
+    function _operationSendMessage(
+        uint256[] memory chainIds,
+        address[] memory stakingProxies,
+        uint256[] memory amounts,
+        bytes[] memory bridgePayloads,
+        uint256[] memory values,
+        bytes32 operation
+    ) private {
+        for (uint256 i = 0; i < chainIds.length; ++i) {
+            if (amounts[i] == 0) continue;
+
+            // Get corresponding deposit processor
+            address depositProcessor = mapChainIdDepositProcessors[chainIds[i]];
+
+            // Check for zero address
+            if (depositProcessor == address(0)) {
+                revert ZeroAddress();
+            }
+
+            // Stake related only
+            if (operation == STAKE) {
+                // Transfer OLAS to depositProcessor
+                IToken(olas).transfer(depositProcessor, amounts[i]);
+            }
+
+            // Perform operation on corresponding Staker on L2
+            IDepositProcessor(depositProcessor).sendMessage{value: values[i]}(stakingProxies[i], amounts[i],
+                bridgePayloads[i], operation);
+        }
     }
 
     /// @dev Depository initializer.
@@ -404,24 +437,8 @@ contract Depository is Implementation {
             IToken(olas).transferFrom(msg.sender, address(this), stakeAmount);
         }
 
-        // Send funds to staking relevant deposit processors
-        for (uint256 i = 0; i < chainIds.length; ++i) {
-            if (amounts[i] == 0) continue;
-
-            // Get Deposit Processor address
-            address depositProcessor = mapChainIdDepositProcessors[chainIds[i]];
-            // Check for zero address
-            if (depositProcessor == address(0)) {
-                revert ZeroAddress();
-            }
-
-            // Approve OLAS for depositProcessor
-            IToken(olas).transfer(depositProcessor, amounts[i]);
-
-            // Transfer OLAS to its corresponding Staker on L2
-            IDepositProcessor(depositProcessor).sendMessage{value: values[i]}(stakingProxies[i], amounts[i],
-                bridgePayloads[i], STAKE);
-        }
+        // Send funds to staking via relevant deposit processors
+        _operationSendMessage(chainIds, stakingProxies, amounts, bridgePayloads, values, STAKE);
 
         // If there are OLAS leftovers, transfer (back) to stOLAS
         if (stakeAmount > actualStakeAmount) {
@@ -503,17 +520,6 @@ contract Depository is Implementation {
                 unstakeAmount = 0;
             }
 
-            // Transfer OLAS via the bridge
-            address depositProcessor = mapChainIdDepositProcessors[chainIds[i]];
-            // Check for zero address
-            if (depositProcessor == address(0)) {
-                revert ZeroAddress();
-            }
-
-            // Transfer OLAS to its corresponding Staker on L2
-            IDepositProcessor(depositProcessor).sendMessage{value: values[i]}(stakingProxies[i], amounts[i],
-                bridgePayloads[i], UNSTAKE);
-
             if (unstakeAmount == 0) {
                 break;
             }
@@ -523,6 +529,75 @@ contract Depository is Implementation {
         if (unstakeAmount > 0) {
             revert Overflow(unstakeAmount, 0);
         }
+
+        // Request unstake via relevant deposit processors
+        _operationSendMessage(chainIds, stakingProxies, amounts, bridgePayloads, values, UNSTAKE);
+
+        emit Unstake(msg.sender, unstakeAmount, chainIds, stakingProxies, amounts);
+    }
+
+    /// @dev Calculates amounts and initiates cross-chain unstake request for specified retired models.
+    /// @notice This action deducts reserves from their staked part and get them back as assets reserved for staking.
+    /// @param chainIds Set of chain Ids with staking proxies.
+    /// @param stakingProxies Set of staking proxies corresponding to each chain Id.
+    /// @param bridgePayloads Bridge payloads corresponding to each chain Id.
+    /// @param values Value amounts for each bridge interaction, if applicable.
+    /// @return amounts Corresponding OLAS amounts for each staking proxy.
+    function unstakeForRetire(
+        uint256[] memory chainIds,
+        address[] memory stakingProxies,
+        bytes[] memory bridgePayloads,
+        uint256[] memory values
+    ) external payable returns (uint256[] memory amounts) {
+        // Reentrancy guard
+        if (_locked) {
+            revert ReentrancyGuard();
+        }
+        _locked = true;
+
+        // Check array lengths
+        if (chainIds.length == 0 || chainIds.length != stakingProxies.length ||
+            chainIds.length != bridgePayloads.length || chainIds.length != values.length) {
+            revert WrongArrayLength();
+        }
+
+        uint256 unstakeAmount;
+
+        // Allocate arrays of max possible size
+        amounts = new uint256[](chainIds.length);
+
+        // Traverse and collect retired models amounts
+        for (uint256 i = 0; i < chainIds.length; ++i) {
+            // Push a pair of key defining variables into one key: chainId | stakingProxy
+            // stakingProxy occupies first 160 bits, chainId occupies next bits as they both fit well in uint256
+            uint256 stakingModelId = uint256(uint160(stakingProxies[i]));
+            stakingModelId |= chainIds[i] << 160;
+
+            StakingModel memory stakingModel = mapStakingModels[stakingModelId];
+            // Check for retired model status
+            if (stakingModel.status != StakingModelStatus.Retired) {
+                revert WrongStakingModel(stakingModelId);
+            }
+
+            // Check for model existence and remainder as Staking Proxy must not be fully unstaked
+            if (stakingModel.supply == 0 || stakingModel.remainder == stakingModel.supply) {
+                revert WrongStakingModel(stakingModelId);
+            }
+
+            // Adjust unstaking amount to not overflow the max allowed one
+            amounts[i] = stakingModel.supply - stakingModel.remainder;
+            if (amounts[i] > stakingModel.stakeLimitPerSlot) {
+                amounts[i] = stakingModel.stakeLimitPerSlot;
+            }
+
+            // Update staking model remainder
+            mapStakingModels[stakingModelId].remainder += uint96(amounts[i]);
+
+            unstakeAmount += amounts[i];
+        }
+
+        // Request unstake for retired models via relevant deposit processors
+        _operationSendMessage(chainIds, stakingProxies, amounts, bridgePayloads, values, UNSTAKE_RETIRED);
 
         emit Unstake(msg.sender, unstakeAmount, chainIds, stakingProxies, amounts);
     }

--- a/contracts/l2/Collector.sol
+++ b/contracts/l2/Collector.sol
@@ -61,6 +61,8 @@ contract Collector is Implementation {
     event ProtocolBalanceUpdated(uint256 protocolBalance);
     event TokensRelayed(address indexed l1Distributor, uint256 amount);
 
+    // Reward transfer operation
+    bytes32 public constant REWARD = 0x0b9821ae606ebc7c79bf3390bdd3dc93e1b4a7cda27aad60646e7b88ff55b001;
     // Min olas balance to relay
     uint256 public constant MIN_OLAS_BALANCE = 1 ether;
     // Max protocol factor
@@ -68,8 +70,6 @@ contract Collector is Implementation {
 
     // OLAS contract address
     address public immutable olas;
-    // Distributor contract address on L1
-    address public immutable l1Distributor;
 
     // Protocol balance
     uint256 public protocolBalance;
@@ -85,10 +85,8 @@ contract Collector is Implementation {
     mapping(bytes32 => ReceiverBalance) public mapOperationReceiverBalances;
 
     /// @param _olas OLAS address on L2.
-    /// @param _l1Distributor Distributor contract address on L1.
-    constructor(address _olas, address _l1Distributor) {
+    constructor(address _olas) {
         olas = _olas;
-        l1Distributor = _l1Distributor;
     }
 
     /// @dev Initializes collector.
@@ -214,7 +212,7 @@ contract Collector is Implementation {
         }
 
         // Rewards are subject to a protocol fee
-        if (receiver == l1Distributor) {
+        if (operation == REWARD) {
             uint256 protocolAmount = (olasBalance * protocolFactor) / MAX_PROTOCOL_FACTOR;
             olasBalance -= protocolAmount;
 

--- a/contracts/l2/Collector.sol
+++ b/contracts/l2/Collector.sol
@@ -39,11 +39,27 @@ error AlreadyInitialized();
 /// @param max Maximum possible value.
 error Overflow(uint256 provided, uint256 max);
 
+/// @dev Wrong length of arrays.
+error WrongArrayLength();
+
+/// @dev Caught reentrancy violation.
+error ReentrancyGuard();
+
+// ReceiverBalance struct
+struct ReceiverBalance {
+    uint256 balance;
+    address receiver;
+}
+
+
 /// @title Collector - Smart contract for collecting staking rewards
 contract Collector is Implementation {
     event StakingProcessorUpdated(address indexed stakingProcessorL2);
+    event OperationReceiversSet(bytes32[] operations, address[] receivers);
+    event OperationReceiverBalancesUpdated(bytes32 indexed operations, address indexed receiver, uint256 balance);
     event ProtocolFactorUpdated(uint256 protocolFactor);
-    event RewardTokensRelayed(address indexed l1Distributor, uint256 amount);
+    event ProtocolBalanceUpdated(uint256 protocolBalance);
+    event TokensRelayed(address indexed l1Distributor, uint256 amount);
 
     // Min olas balance to relay
     uint256 public constant MIN_OLAS_BALANCE = 1 ether;
@@ -61,6 +77,12 @@ contract Collector is Implementation {
     uint256 public protocolFactor;
     // L2 staking processor address
     address public l2StakingProcessor;
+
+    // Reentrancy lock
+    uint256 internal _locked = 1;
+
+    // Mapping of operation => OLAS balance and L1 address to send to
+    mapping(bytes32 => ReceiverBalance) public mapOperationReceiverBalances;
 
     /// @param _olas OLAS address on L2.
     /// @param _l1Distributor Distributor contract address on L1.
@@ -111,38 +133,109 @@ contract Collector is Implementation {
         emit ProtocolFactorUpdated(newProtocolFactor);
     }
 
-    /// @dev Relays reward tokens to L1.
-    /// @param bridgePayload Bridge payload.
-    function relayRewardTokens(bytes memory bridgePayload) external payable {
-        // Get OLAS balance
-        uint256 olasBalance = IToken(olas).balanceOf(address(this));
-        // Get current protocol balance
-        uint256 curProtocolBalance = protocolBalance;
-
-        // Overflow check: this must never happen, as protocol balance is included in total OLAS balance
-        if (olasBalance < curProtocolBalance) {
-            revert Overflow(olasBalance, curProtocolBalance);
+    function setOperationReceivers(bytes32[] memory operations, address[] memory receivers) external {
+        // Check for ownership
+        if (msg.sender != owner) {
+            revert OwnerOnly(msg.sender, owner);
         }
 
-        uint256 amount = olasBalance - curProtocolBalance;
+        // Check array lengths
+        if (operations.length == 0 || operations.length != receivers.length) {
+            revert WrongArrayLength();
+        }
+
+        for (uint256 i = 0; i < operations.length; ++i) {
+            // Check for zero value
+            if (operations[i] == 0) {
+                revert ZeroValue();
+            }
+
+            // Check for zero address
+            if (receivers[i] == address(0)) {
+                revert ZeroAddress();
+            }
+
+            ReceiverBalance storage receiverBalance = mapOperationReceiverBalances[operations[i]];
+            receiverBalance.receiver = receivers[i];
+        }
+
+        emit OperationReceiversSet(operations, receivers);
+    }
+
+    function topUpBalance(uint256 amount, bytes32 operation) external {
+        // Reentrancy guard
+        if (_locked == 2) {
+            revert ReentrancyGuard();
+        }
+        _locked = 2;
+
+        ReceiverBalance storage receiverBalance = mapOperationReceiverBalances[operation];
+
+        // Get receiver address
+        address receiver = receiverBalance.receiver;
+        // Check for zero address
+        if (receiverBalance.receiver == address(0)) {
+            revert ZeroAddress();
+        }
+
+        IToken(olas).transferFrom(msg.sender, address(this), amount);
+        uint256 balance = receiverBalance.balance + amount;
+        receiverBalance.balance = balance;
+
+        emit OperationReceiverBalancesUpdated(operation, receiver, balance);
+
+        _locked = 1;
+    }
+
+    /// @dev Relays tokens to L1.
+    /// @param operation Operation type related to L1 receiver.
+    /// @param bridgePayload Bridge payload.
+    function relayTokens(bytes32 operation, bytes memory bridgePayload) external payable {
+        // Reentrancy guard
+        if (_locked == 2) {
+            revert ReentrancyGuard();
+        }
+        _locked = 2;
+
+        ReceiverBalance storage receiverBalance = mapOperationReceiverBalances[operation];
+
+        // Get receiver address
+        address receiver = receiverBalance.receiver;
+        // Check for zero address
+        if (receiver == address(0)) {
+            revert ZeroAddress();
+        }
+
+        // Get OLAS balance
+        uint256 olasBalance = receiverBalance.balance;
         // Check for minimum balance
-        if (amount < MIN_OLAS_BALANCE) {
+        if (olasBalance < MIN_OLAS_BALANCE) {
             revert ZeroValue();
         }
 
-        uint256 protocolAmount = (olasBalance * protocolFactor) / MAX_PROTOCOL_FACTOR;
-        amount -= protocolAmount;
+        // Rewards are subject to a protocol fee
+        if (receiver == l1Distributor) {
+            uint256 protocolAmount = (olasBalance * protocolFactor) / MAX_PROTOCOL_FACTOR;
+            olasBalance -= protocolAmount;
 
-        // Update protocol balance
-        curProtocolBalance += protocolAmount;
-        protocolBalance = curProtocolBalance;
+            // Update protocol balance
+            uint256 curProtocolBalance = protocolBalance + protocolAmount;
+            protocolBalance = curProtocolBalance;
 
-        emit RewardTokensRelayed(l1Distributor, amount);
+            emit ProtocolBalanceUpdated(curProtocolBalance);
+        }
+
+        // Zero operation balance
+        receiverBalance.balance = 0;
+
+        emit TokensRelayed(receiver, olasBalance);
 
         // Transfer tokens
-        IToken(olas).transfer(l2StakingProcessor, amount);
+        IToken(olas).transfer(l2StakingProcessor, olasBalance);
 
         // Send tokens to L1
-        IBridge(l2StakingProcessor).relayToL1{value: msg.value}(l1Distributor, amount, bridgePayload);
+        IBridge(l2StakingProcessor).relayToL1{value: msg.value}(receiver, olasBalance, bridgePayload);
+
+        _locked = 1;
     }
 }

--- a/contracts/l2/StakingManager.sol
+++ b/contracts/l2/StakingManager.sol
@@ -98,8 +98,6 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
     address public immutable serviceManager;
     // OLAS token address
     address public immutable olas;
-    // Treasury address on L1
-    address public immutable l1Treasury;
     // Service registry address
     address public immutable serviceRegistry;
     // Service registry token utility address
@@ -140,7 +138,6 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
 
     /// @dev StakerL2 constructor.
     /// @param _olas OLAS token address.
-    /// @param _l1Treasury Treasury address on L1.
     /// @param _serviceManager Service manager address.
     /// @param _stakingFactory Staking factory address.
     /// @param _safeModuleInitializer Safe module initializer address.
@@ -151,7 +148,6 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
     /// @param _configHash Contributor service config hash.
     constructor(
         address _olas,
-        address _l1Treasury,
         address _serviceManager,
         address _stakingFactory,
         address _safeModuleInitializer,
@@ -162,9 +158,9 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
         bytes32 _configHash
     ) {
         // Check for zero addresses
-        if (_olas == address(0) || _l1Treasury == address(0) || _serviceManager == address(0) ||
-            _stakingFactory == address(0) || _safeModuleInitializer ==address(0) || _safeL2 == address(0) ||
-            _beacon ==address(0) || _collector == address(0))
+        if (_olas == address(0) || _serviceManager == address(0) || _stakingFactory == address(0) ||
+            _safeModuleInitializer ==address(0) || _safeL2 == address(0) || _beacon ==address(0) ||
+            _collector == address(0))
         {
             revert ZeroAddress();
         }
@@ -178,7 +174,6 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
         configHash = _configHash;
 
         olas = _olas;
-        l1Treasury = _l1Treasury;
         serviceManager = _serviceManager;
         stakingFactory = _stakingFactory;
         safeModuleInitializer = _safeModuleInitializer;
@@ -434,7 +429,7 @@ contract StakingManager is Implementation, ERC721TokenReceiver {
         }
         _locked = 2;
 
-        // Check for treasury requesting withdraw
+        // Check for l2StakingProcessor to be a sender
         if (msg.sender != l2StakingProcessor) {
             revert UnauthorizedAccount(msg.sender);
         }

--- a/contracts/l2/bridging/DefaultStakingProcessorL2.sol
+++ b/contracts/l2/bridging/DefaultStakingProcessorL2.sol
@@ -11,7 +11,10 @@ interface IStakingManager {
     /// @notice Unstakes services if needed to satisfy withdraw requests.
     ///         Call this to unstake definitely terminated staking contracts - deactivated on L1 and / or ran out of funds.
     ///         The majority of discovered chains does not need any value to process token bridge transfer.
-    function unstake(address stakingProxy, uint256 amount) external;
+    /// @param stakingProxy Staking proxy address.
+    /// @param amount Unstake amount.
+    /// @param operation Unstake operation type.
+    function unstake(address stakingProxy, uint256 amount, bytes32 operation) external;
 }
 
 // Necessary ERC20 token interface
@@ -185,7 +188,7 @@ abstract contract DefaultStakingProcessorL2 is IBridgeErrors {
             }
         } else if (operation == UNSTAKE) {
             // This is a low level call since it must never revert
-            bytes memory unstakeData = abi.encodeCall(IStakingManager.unstake, (target, amount));
+            bytes memory unstakeData = abi.encodeCall(IStakingManager.unstake, (target, amount, operation));
             (bool success, ) = stakingManager.call(unstakeData);
 
             if (!success) {
@@ -289,7 +292,7 @@ abstract contract DefaultStakingProcessorL2 is IBridgeErrors {
                 revert InsufficientBalance(olasBalance, amount);
             }
         } else if (operation == UNSTAKE) {
-            IStakingManager(stakingManager).unstake(target, amount);
+            IStakingManager(stakingManager).unstake(target, amount, operation);
         } else {
             // Must never happen
             revert OperationNotFound(operation);


### PR DESCRIPTION
- Separate stake, unstake, unstake_retired, reward operations;
- Collector is now getting balances for all the operations and sets corresponding addresses on L1 to transfer those balances to.